### PR TITLE
fix for incessant reconciles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ test: manifests generate fmt vet envtest ## Run tests.
 ##@ Build
 .PHONY: run
 run: manifests generate fmt vet ## Run against the configured Kubernetes cluster in ~/.kube/config
-	helm-operator run
+	helm-operator run --zap-devel
 #	$(HELM_OPERATOR) run
 	
 .PHONY: docker-build

--- a/config/rbac/airflow-helm-postgresql_Role.yml
+++ b/config/rbac/airflow-helm-postgresql_Role.yml
@@ -1,25 +1,3 @@
----
-# Source: airflow/charts/postgresql/templates/role.yaml
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: airflow-helm-postgresql
-  labels:
-    app.kubernetes.io/name: postgresql
-    helm.sh/chart: postgresql-12.1.9
-    app.kubernetes.io/instance: airflow-helm
-    app.kubernetes.io/managed-by: Helm
-# yamllint disable rule:indentation
-rules:
-  - apiGroups:
-      - security.openshift.io
-    resourceNames:
-      - anyuid
-    resources:
-      - securitycontextconstraints
-    verbs:
-      - use
-# Source: airflow/templates/rbac/pod-launcher-role.yaml
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -36,3 +14,22 @@ rules:
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: airflow-helm-postgresql
+  labels:
+    helm.sh/chart: postgresql-12.1.9
+    app.kubernetes.io/instance: airflow-helm
+    app.kubernetes.io/managed-by: Helm
+# yamllint disable rule:indentation
+rules:
+  - apiGroups:
+      - security.openshift.io
+    resourceNames:
+      - anyuid
+    resources:
+      - securitycontextconstraints
+    verbs:
+      - use

--- a/config/rbac/airflow-helm-postgresql_RoleBinding.yml
+++ b/config/rbac/airflow-helm-postgresql_RoleBinding.yml
@@ -1,23 +1,3 @@
----
-# Source: airflow/charts/postgresql/templates/rolebinding.yaml
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: airflow-helm-postgresql
-  labels:
-    app.kubernetes.io/name: postgresql
-    helm.sh/chart: postgresql-12.1.9
-    app.kubernetes.io/instance: airflow-helm
-    app.kubernetes.io/managed-by: Helm
-roleRef:
-  kind: Role
-  name: airflow-helm-postgresql
-  apiGroup: rbac.authorization.k8s.io
-subjects:
-  - kind: ServiceAccount
-    name: airflow-helm-postgresql
-    namespace: "airflow-helm"
-# Source: airflow/templates/rbac/pod-launcher-rolebinding.yaml
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -34,3 +14,20 @@ subjects:
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: airflow-helm-postgresql
+  labels:
+    helm.sh/chart: postgresql-12.1.9
+    app.kubernetes.io/instance: airflow-helm
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  kind: Role
+  name: airflow-helm-postgresql
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: airflow-helm-postgresql
+    namespace: "airflow-helm"

--- a/config/rbac/airflow-helm-postgresql_ServiceAccount.yml
+++ b/config/rbac/airflow-helm-postgresql_ServiceAccount.yml
@@ -1,17 +1,3 @@
----
-# Source: airflow/charts/postgresql/templates/serviceaccount.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: airflow-helm-postgresql
-  labels:
-    app.kubernetes.io/name: postgresql
-    helm.sh/chart: postgresql-12.1.9
-    app.kubernetes.io/instance: airflow-helm
-    app.kubernetes.io/managed-by: Helm
-  annotations:
-automountServiceAccountToken: true
-# Source: airflow/templates/jobs/create-user-job-serviceaccount.yaml
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -28,3 +14,14 @@ automountServiceAccountToken: true
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: airflow-helm-postgresql
+  labels:
+    helm.sh/chart: postgresql-12.1.9
+    app.kubernetes.io/instance: airflow-helm
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+automountServiceAccountToken: true

--- a/config/samples/workflow_v1alpha1_airflow.yaml
+++ b/config/samples/workflow_v1alpha1_airflow.yaml
@@ -10,25 +10,26 @@ spec:
     serviceAccount:
       create: false
       name: airflow-helm-create-user-job
-  dagProcessor:
-    serviceAccount:
-      create: false
-      name: airflow-helm-worker
-  flower:
-    serviceAccount:
-      create: false
-      name: airflow-helm-webserver
+  # dagProcessor:
+  #   serviceAccount:
+  #     create: false
+  #     name: airflow-helm-worker
+  # flower:
+  #   serviceAccount:
+  #     create: false
+  #     name: airflow-helm-webserver
   migrateDatabaseJob:
     serviceAccount:
       create: false
       name: airflow-helm-migrate-database-job
-  pgbouncer:
-    serviceAccount:
-      create: false
-      name: airflow-helm-postgresql
+  # pgbouncer:
+  #   serviceAccount:
+  #     create: false
+  #     name: airflow-helm-postgresql
   postgresql:
     rbac:
       create: false
+      name: airflow-helm-postgresql
     serviceAccount:
       create: false
       name: airflow-helm-postgresql
@@ -48,6 +49,7 @@ spec:
     serviceAccount:
       create: false
       name: airflow-helm-triggerer
+  webserverSecretKeySecretName: webserver-secret
   webserver:
     serviceAccount:
       create: false

--- a/hack/airflow-helm-redis-rb.yaml
+++ b/hack/airflow-helm-redis-rb.yaml
@@ -1,0 +1,16 @@
+# The official airflow helm chart's redis component does not autogenerate the 
+# required rbac for redis to work on openshift ootb so piggy-back on postgres
+# role to get anyuid when testing helmchart on openshift
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: airflow-helm-redis
+  namespace: airflow-helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: airflow-helm-postgresql
+subjects:
+- kind: ServiceAccount
+  name: airflow-helm-redis
+  namespace: airflow-helm

--- a/hack/hacks.txt
+++ b/hack/hacks.txt
@@ -22,5 +22,10 @@ In order to extract the required RBAC yamls from the helm chart the `helm templa
 ### Split rbac_no_ns.yaml
 `yq -s '.metadata.name + "_" + .kind' rbac_no_ns.yaml`
 
+### Missing redis anyuid
+
+### Static webserver serviceAccount
+`kubectl create secret generic webserver-secret --from-literal="webserver-secret-key=$(python3 -c 'import secrets; print(secrets.token_hex(16))')"`
+
 ### TODO: set suggested namespace 
 Cluster role bindings expect the operand to be deployed in the airlfow-helm namespace if this is not the case, additional clusterrolebingings would have to manually be created.


### PR DESCRIPTION
turns out the reason for the incessant reconciles was due to the use of a dynamic webserver secret, switching to a static secret as suggested by airflows production guide resolved the issue.